### PR TITLE
Sorted prop types

### DIFF
--- a/eslint-react/index.js
+++ b/eslint-react/index.js
@@ -24,6 +24,8 @@ module.exports = {
 			},
 		],
 
+		'react/sort-prop-types': 'error',
+
 		'react/jsx-closing-bracket-location': [
 			'error',
 			'line-aligned',


### PR DESCRIPTION
I do not feel strongly about prop sorting (although I prefer it), but we already comment on PRs to request this change. I'd rather use this lint rule.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md