### PR TITLE
Prohibit JSX curly bracket spaces

### DIFF
--- a/eslint-react/index.js
+++ b/eslint-react/index.js
@@ -36,6 +36,14 @@ module.exports = {
 			'never',
 		],
 
+		'react/jsx-curly-spacing': [
+			'error',
+			{
+				when: 'never',
+				children: true,
+			},
+		],
+
 		'react/jsx-indent-props': [
 			'error',
 			'tab',

--- a/eslint-react/package-lock.json
+++ b/eslint-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-react/package.json
+++ b/eslint-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "repository": "https://github.com/Quartz/lint",
   "main": "index.js",


### PR DESCRIPTION
Context: https://github.com/Quartz/qz-react/pull/3436#issuecomment-511971524

Another one in the "we do this informally, might as well make it autofixable" category.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md

When {"when": "never", "children": true } is set, the following patterns are considered warnings:

```
<Hello name={ firstname } />;
<Hello name={ firstname} />;
<Hello name={firstname } />;
<Hello>{ firstname }</Hello>;
```

The following patterns are not warnings:

```
<Hello name={firstname} />;
<Hello name={{ firstname: 'John', lastname: 'Doe' }} />;
<Hello name={
  firstname
} />;
<Hello>{firstname}</Hello>;
<Hello>{
  firstname
}</Hello>;
```