### PR TITLE
1.4.0

### DIFF
--- a/eslint-base/index.js
+++ b/eslint-base/index.js
@@ -22,6 +22,7 @@ module.exports = {
 	},
 
 	plugins: [
+		'es',
 		'import',
 		'jest',
 		'testcafe',
@@ -86,6 +87,18 @@ module.exports = {
 		'eol-last': [
 			'error',
 			'always',
+		],
+
+		'es/no-regexp-lookbehind-assertions': [
+			'error',
+		],
+
+		'es/no-regexp-named-capture-groups': [
+			'error',
+		],
+
+		'es/no-regexp-s-flag': [
+			'error',
 		],
 
 		'import/no-unresolved': [

--- a/eslint-base/package-lock.json
+++ b/eslint-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-base",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -542,6 +542,22 @@
         }
       }
     },
+    "eslint-plugin-es": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+        }
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.0.tgz",
@@ -601,6 +617,14 @@
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "eslint-visitor-keys": {

--- a/eslint-base/package.json
+++ b/eslint-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-base",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "",
   "repository": "https://github.com/Quartz/lint",
   "main": "index.js",
@@ -14,6 +14,7 @@
     "babel-eslint": "^10.0.2",
     "eslint": "^4.14.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-es": "^1.4.0",
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-jest": "^21.27.2",
     "eslint-plugin-testcafe": "^0.2.1"


### PR DESCRIPTION
- Adds eslint-plugin-es for access to some linting rules around es2018 syntax
- updates version
- I defaulted to the rules around regex for now but add'l rules/guide is here: https://mysticatea.github.io/eslint-plugin-es/