### PR TITLE
eslint-base version bump

### DIFF
--- a/eslint-base/package-lock.json
+++ b/eslint-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-base",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-base/package.json
+++ b/eslint-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-base",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "repository": "https://github.com/Quartz/lint",
   "main": "index.js",


### PR DESCRIPTION
Missed this from https://github.com/Quartz/lint/pull/8

Bumps eslint-base to v1.2.0 to match npm version