### PR TITLE
No extra parens

### DIFF
--- a/eslint-base/index.js
+++ b/eslint-base/index.js
@@ -156,6 +156,14 @@ module.exports = {
 
 		'no-else-return': 'error',
 
+		'no-extra-parens': [
+			'error',
+			'all',
+			{
+				ignoreJSX: 'all',
+			},
+		],
+
 		'no-nested-ternary': 'error',
 
 		'no-mixed-spaces-and-tabs': 'error',

--- a/eslint-base/package-lock.json
+++ b/eslint-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-base",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-base/package.json
+++ b/eslint-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/eslint-config-base",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "repository": "https://github.com/Quartz/lint",
   "main": "index.js",


### PR DESCRIPTION
Adds https://eslint.org/docs/rules/no-extra-parens

Has an autofix so we can clean up violations on qz-react easily (there are lots of them!)

Uses the `ignoreJSX` option otherwise this would fail:

```
const MyComponent = () => (
  <div>
    <span>hello</span>
  </div>
);
```

Which would be overkill
